### PR TITLE
pip install `akinator.py` to `akinator`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ To get async support plus faster performance (via the ``aiodns`` and ``cchardet`
     python3 -m pip install "akinator[fast_async]"
 
     # Windows
-    py -m pip pip install "akinator[fast_async]"
+    py -m pip install "akinator[fast_async]"
 
 
 To install the development version, do the following:

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,10 @@ To install the regular library without asynchronous support, just run the follow
 .. code-block:: sh
 
     # Unix / macOS
-    python3 -m pip install "akinator.py"
+    python3 -m pip install akinator
 
     # Windows
-    py -m pip install "akinator.py"
+    py -m pip install akinator
 
 
 Otherwise, to get asynchronous support, do:
@@ -35,10 +35,10 @@ Otherwise, to get asynchronous support, do:
 .. code-block:: sh
 
     # Unix / macOS
-    python3 -m pip install "akinator.py[async]"
+    python3 -m pip install akinator[async]
 
     # Windows
-    py -m pip install "akinator.py[async]"
+    py -m pip install akinator[async]
 
 
 To get async support plus faster performance (via the ``aiodns`` and ``cchardet`` libraries), do:
@@ -46,10 +46,10 @@ To get async support plus faster performance (via the ``aiodns`` and ``cchardet`
 .. code-block:: sh
 
     # Unix / macOS
-    python3 -m pip install "akinator.py[fast_async]"
+    python3 -m pip install akinator[fast_async]
 
     # Windows
-    py -m pip install "akinator.py[fast_async]"
+    py -m pip pip install akinator[fast_async]
 
 
 To install the development version, do the following:

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,10 @@ To install the regular library without asynchronous support, just run the follow
 .. code-block:: sh
 
     # Unix / macOS
-    python3 -m pip install akinator
+    python3 -m pip install "akinator"
 
     # Windows
-    py -m pip install akinator
+    py -m pip install "akinator"
 
 
 Otherwise, to get asynchronous support, do:
@@ -35,10 +35,10 @@ Otherwise, to get asynchronous support, do:
 .. code-block:: sh
 
     # Unix / macOS
-    python3 -m pip install akinator[async]
+    python3 -m pip install "akinator[async]"
 
     # Windows
-    py -m pip install akinator[async]
+    py -m pip install "akinator[async]"
 
 
 To get async support plus faster performance (via the ``aiodns`` and ``cchardet`` libraries), do:
@@ -46,10 +46,10 @@ To get async support plus faster performance (via the ``aiodns`` and ``cchardet`
 .. code-block:: sh
 
     # Unix / macOS
-    python3 -m pip install akinator[fast_async]
+    python3 -m pip install "akinator[fast_async]"
 
     # Windows
-    py -m pip pip install akinator[fast_async]
+    py -m pip pip install "akinator[fast_async]"
 
 
 To install the development version, do the following:


### PR DESCRIPTION
`pip install akinator.py` installs an obsolete version of akinator.py such as `v0.0.2`. I'm not sure if that even is the same repo. `pip install akinator` is the one that is actually your repo. Check https://pypi.org/project/akinator/